### PR TITLE
fix: fix amazonlinxu version 2

### DIFF
--- a/modules/oauth2/lambda/Dockerfile
+++ b/modules/oauth2/lambda/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux
+FROM amazonlinux:2
 
 WORKDIR /tmp
 #install the dependencies


### PR DESCRIPTION
## 概要
- Dockerfile の amazonlinux のバージョンを 2 に固定しました。
  - latest (=2023) の場合、amazon-linux-extras がないため
